### PR TITLE
Finalize SMS gateway CI, docs and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,14 @@
 # Path to the modem device (e.g. /dev/ttyUSB0)
 DEVICE=/dev/ttyUSB0
+
 # Serial baud rate for the modem
 BAUDRATE=115200
+
 # Telegram bot token used to send messages
-TELEGRAM_BOT_TOKEN=
+TELEGRAM_BOT_TOKEN=123:ABC
+
 # Telegram chat ID where SMS will be forwarded
-TELEGRAM_CHAT_ID=
+TELEGRAM_CHAT_ID=123456
+
 # Optional log level for gammu (1..3)
 LOGLEVEL=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,14 @@
-name: build-and-push
+name: ci
+
 on:
   push:
-    branches: [ main ]
-    tags: [ '*' ]
+    branches: [main]
+    tags: ['*']
+  pull_request:
+    branches: [main]
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,46 +21,51 @@ jobs:
 
       - name: Run unit tests and fail if none are found
         run: |
-          output=$(python -m unittest discover -s tests -v || true)
+          set -e
+          output=$(python -m unittest discover -s tests -v)
           echo "$output"
           if echo "$output" | grep -q 'Ran 0 tests'; then
-            echo "ERROR: No tests were executed. Failing the build."
+            echo "ERROR: No tests were executed."
             exit 1
           fi
 
       - name: Set image tags
+        if: github.event_name != 'pull_request'
         id: vars
         run: |
-          REPO=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          REPO=ghcr.io/$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
           TAGS="$REPO:${GITHUB_SHA}"
-          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             TAGS="$TAGS,$REPO:${GITHUB_REF_NAME}"
           fi
-          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
             TAGS="$TAGS,$REPO:latest"
           fi
-          echo "IMAGE=$REPO" >> $GITHUB_ENV
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          echo "IMAGE=$REPO" >> $GITHUB_ENV
 
       - uses: docker/setup-buildx-action@v3
+        if: github.event_name != 'pull_request'
 
       - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/build-push-action@v5
+        if: github.event_name != 'pull_request'
         with:
           context: .
           push: true
-
           tags: ${{ steps.vars.outputs.tags }}
 
-      - name: Smoke test
+      - name: Smoke test container
+        if: github.event_name != 'pull_request'
         run: |
           IMAGE=$(echo "${{ steps.vars.outputs.tags }}" | cut -d',' -f1)
-          docker run --rm --entrypoint python3 \
-            -e DEVICE=/dev/null -e BAUDRATE=9600 \
+          docker run --rm -e DEVICE=/dev/null -e BAUDRATE=9600 \
             -e TELEGRAM_BOT_TOKEN=dummy -e TELEGRAM_CHAT_ID=dummy \
-            "$IMAGE" -m py_compile /app/on_receive.py
+            "$IMAGE" --dry-run
+          docker run --rm --entrypoint gammu-smsd "$IMAGE" --version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # SMS Gateway → Telegram
 
-This container forwards incoming SMS from a USB modem (tested with Huawei E352) to a Telegram chat. It should work with any modem supported by `gammu`.
+This project provides a simple gateway that forwards incoming SMS messages from a USB modem to a Telegram chat using `gammu`.
+
+## Quickstart
+1. Pull the image from GitHub Container Registry
+   ```sh
+   docker pull ghcr.io/owner/sms-gateway:latest
+   ```
+2. Copy the example environment file and edit it
+   ```sh
+   cp .env.example .env
+   # edit .env with your values
+   ```
+3. Start the service
+   ```sh
+   docker compose up -d
+   ```
 
 ## Environment variables
 | Variable | Description | Example |
@@ -11,24 +26,15 @@ This container forwards incoming SMS from a USB modem (tested with Huawei E352) 
 | `TELEGRAM_CHAT_ID` | Telegram chat ID that will receive messages | `123456` |
 | `LOGLEVEL` | Optional gammu debug level (1..3) | `1` |
 
-Copy `.env.example` to `.env` and fill in these values.
+Copy `.env.example` to `.env` and fill in these values before starting the container.
 
 ## Usage
-### Option 1: pull ready image
-```bash
-docker pull ghcr.io/owner/sms-gateway:latest
-cp .env.example .env
-docker compose up -d
-```
-
-### Option 2: build locally
+### Build locally
 ```bash
 git clone https://github.com/owner/sms-gateway.git
 cd sms-gateway
 cp .env.example .env
 docker compose up -d
-# or for local testing
-python3 on_receive.py
 ```
 
 The container runs as root because USB devices usually require privileged access.
@@ -37,16 +43,16 @@ The container runs as root because USB devices usually require privileged access
 - `./state` → `/var/spool/gammu` – incoming/outgoing SMS and log files
 - `./smsdrc` → `/etc/gammu-smsdrc` – override gammu configuration
 
+## Running Tests Locally
+Install dependencies and run the test suite:
+```sh
+pip install -r requirements.txt
+python -m unittest discover -s tests -v
+```
+
 ## Troubleshooting
 1. **Ports are visible on host?** `ls -l /dev/ttyUSB*`
 2. **Port free?** `sudo fuser -v /dev/ttyUSB0`
 3. **Modem responds?** `docker exec -it sms-gateway gammu -c /etc/gammu-smsdrc --identify`
 4. **Service initialized?** `docker logs -f sms-gateway | tail`
 5. **Message delivered to Telegram?** Check container logs for errors.
-
-## Running tests
-Install dependencies and run the test suite:
-```bash
-pip install -r requirements.txt
-python3 -m unittest discover -s tests -v
-```

--- a/start.sh
+++ b/start.sh
@@ -34,4 +34,9 @@ else
     log "Using existing smsdrc from volume"
 fi
 
+if [ "${1:-}" = "--dry-run" ]; then
+    log "Dry run requested - not starting gammu-smsd"
+    exit 0
+fi
+
 exec gammu-smsd -c /etc/gammu-smsdrc

--- a/tests/test_start_sh.py
+++ b/tests/test_start_sh.py
@@ -1,0 +1,26 @@
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class TestStartScript(unittest.TestCase):
+    def test_dry_run(self):
+        env = os.environ.copy()
+        env.update({
+            'DEVICE': '/dev/null',
+            'BAUDRATE': '9600',
+            'TELEGRAM_BOT_TOKEN': 'x',
+            'TELEGRAM_CHAT_ID': 'x',
+        })
+        config = Path('/etc/gammu-smsdrc')
+        if config.exists():
+            config.unlink()
+        subprocess.run(['bash', 'start.sh', '--dry-run'], check=True, env=env)
+        self.assertTrue(config.exists())
+        config.unlink()
+        self.assertTrue(Path('/var/spool/gammu').exists())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add CI pipeline running lint/test on all pushes and PRs
- publish container and run smoke test on main/tags only
- document quickstart, env vars, running tests
- provide example environment file
- add dry run flag to start.sh
- add unit test for start.sh dry run

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_687a988c7dd083339c62e3911af047e1