### PR TITLE
Automate modem discovery and self-healing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,27 @@ jobs:
             "$IMAGE" --dry-run
           docker run --rm --entrypoint gammu-smsd "$IMAGE" --version
 
+      - name: Compose up (no modem)
+        if: github.event_name != 'pull_request'
+        run: |
+          IMAGE=$(echo "${{ steps.vars.outputs.tags }}" | cut -d',' -f1)
+          cat > compose.yml <<EOF
+          services:
+            smsgateway:
+              image: $IMAGE
+              group_add:
+                - dialout
+              devices:
+                - /dev/serial/by-id/:/dev/serial/by-id/
+              environment:
+                TELEGRAM_BOT_TOKEN: dummy
+                TELEGRAM_CHAT_ID: dummy
+          EOF
+          docker compose -f compose.yml up -d
+          sleep 30
+          docker compose -f compose.yml ps
+          docker compose -f compose.yml down
+
       - uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ RUN apt-get update && \
         gammu gammu-smsd usbutils procps && \
     rm -rf /var/lib/apt/lists/*
 
+RUN usermod -a -G dialout root
+
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 WORKDIR /app
 COPY . /app
 RUN chmod +x /app/start.sh
-
-ENTRYPOINT ["/app/start.sh"]
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ export GAMMU_CONFIG_PATH=/tmp/smsdrc
 ## Environment variables
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `DEVICE` | Path to the modem device | `/dev/ttyUSB0` |
-| `BAUDRATE` | Serial baud rate | `115200` |
+| `MODEM_DEVICE` | Optional fixed modem device | `/dev/ttyUSB0` |
+| `DEVICE` | *(legacy)* Path to the modem device | `/dev/ttyUSB0` |
+| `BAUDRATE` | *(legacy)* Serial baud rate | `115200` |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token used for sending messages | `123:ABC` |
 | `TELEGRAM_CHAT_ID` | Telegram chat ID that will receive messages | `123456` |
 | `LOGLEVEL` | Optional gammu debug level (1..3) | `1` |
@@ -44,6 +45,25 @@ cd sms-gateway
 cp .env.example .env
 docker compose up -d
 ```
+
+## Fire-and-Forget Deployment
+After starting, the container automatically searches for a Huawei modem and keeps
+`gammu-smsd` running even if the USB port changes.
+
+```bash
+docker compose up -d
+docker compose logs -f smsgateway
+# look for “✅  Using modem …”
+```
+
+Run the container as root or add your user to `dialout` once:
+```bash
+sudo usermod -aG dialout $USER
+```
+
+You can optionally pin the modem with `MODEM_DEVICE=/dev/ttyUSB0`.
+Stable names under `/dev/serial/by-id/` work out of the box, but you can also
+create a custom udev rule if needed.
 
 The container runs as root because USB devices usually require privileged access.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,18 @@
 services:
-  sms_forwarder:
-    container_name: sms-gateway
+  smsgateway:
+    container_name: smsgateway
     image: ghcr.io/owner/sms-gateway:latest
     build: .
-    privileged: true
+    group_add: [dialout]
     devices:
-      - "${DEVICE}:${DEVICE}"
+      - /dev/serial/by-id/:/dev/serial/by-id/
     env_file:
       - .env
     restart: unless-stopped
     volumes:
       - ./state:/var/spool/gammu
-      - ./smsdrc:/etc/gammu-smsdrc:ro
     healthcheck:
-      test: ["CMD-SHELL", "gammu --identify -c /etc/gammu-smsdrc >/dev/null 2>&1"]
+      test: ["CMD-SHELL", "gammu --identify -c /tmp/gammu-smsdrc >/dev/null 2>&1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log(){ echo "[entrypoint] $*"; }
+
+MODEM_DEVICE="${MODEM_DEVICE:-}"
+LOGLEVEL="${LOGLEVEL:-1}"
+GAMMU_SPOOL_PATH="${GAMMU_SPOOL_PATH:-/var/spool/gammu}"
+GAMMU_CONFIG_PATH="${GAMMU_CONFIG_PATH:-/tmp/gammu-smsdrc}"
+
+mkdir -p "$GAMMU_SPOOL_PATH"/{inbox,outbox,sent,error,archive}
+
+device_ok(){
+    local dev="$1"
+    if timeout 3 gammu --device "$dev" --connection at115200 --at "AT" 2>&1 | grep -q "OK"; then
+        return 0
+    fi
+    return 1
+}
+
+find_modem(){
+    if [ -n "$MODEM_DEVICE" ] && device_ok "$MODEM_DEVICE"; then
+        echo "$MODEM_DEVICE"
+        return 0
+    fi
+    for dev in /dev/serial/by-id/usb-Huawei_Technologies_HUAWEI_Mobile-*; do
+        [ -e "$dev" ] || continue
+        if device_ok "$dev"; then
+            echo "$dev"
+            return 0
+        fi
+    done
+    for dev in /dev/ttyUSB* /dev/ttyACM*; do
+        [ -e "$dev" ] || continue
+        if device_ok "$dev"; then
+            echo "$dev"
+            return 0
+        fi
+    done
+    return 1
+}
+
+generate_config(){
+    local dev="$1"
+    cat > "$GAMMU_CONFIG_PATH" <<EOF_CONF
+[gammu]
+device = $dev
+connection = at115200
+logformat = textalldate
+
+[smsd]
+service = files
+inboxpath = ${GAMMU_SPOOL_PATH}/inbox/
+outboxpath = ${GAMMU_SPOOL_PATH}/outbox/
+sentpath = ${GAMMU_SPOOL_PATH}/sent/
+errorpath = ${GAMMU_SPOOL_PATH}/error/
+RunOnReceive = python3 /app/on_receive.py
+debuglevel = ${LOGLEVEL}
+logfile = /dev/stdout
+EOF_CONF
+}
+
+while true; do
+    if dev=$(find_modem); then
+        generate_config "$dev"
+        log "✅  Using modem $dev"
+        if gammu-smsd -c "$GAMMU_CONFIG_PATH"; then
+            log "gammu-smsd exited normally"
+        else
+            log "gammu-smsd crashed, restarting" 
+        fi
+    else
+        log "Waiting for modem ..."
+        sleep 5
+        continue
+    fi
+    sleep 5
+done

--- a/tests/test_on_receive.py
+++ b/tests/test_on_receive.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from unittest import mock
 


### PR DESCRIPTION
## Summary
- add entrypoint script that detects modem, runs gammu-smsd and retries on failure
- ensure root user is in dialout group and use new entrypoint in Dockerfile
- update docker-compose for by-id device mapping
- document fire-and-forget deployment in README
- adjust CI workflow to verify container stays running without a modem
- clean up ruff warning in tests

## Testing
- `python -m unittest discover -s tests -v`
- `ruff check .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_687ac2595a1483339aad4afa80d755bc