### PR TITLE
Add GHCR package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,27 @@
+name: package
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest
+

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ The CI pipeline runs these tests both on the host and again inside the built
 Docker image. The image is only pushed if all tests succeed, ensuring you can
 `docker pull` with confidence.
 
+## Release pipeline
+The Docker image is published to GitHub Container Registry whenever a git tag is pushed.
+
+**Secrets required**: none (uses the built-in `GITHUB_TOKEN`).
+
+Release with:
+
+```sh
+git tag <version> && git push --tags
+```
+
 ## Troubleshooting
 1. **Ports are visible on host?** `ls -l /dev/ttyUSB*`
 2. **Port free?** `sudo fuser -v /dev/ttyUSB0`


### PR DESCRIPTION
## Summary
- add new GitHub Actions workflow to publish Docker images to GHCR on tag push
- document release process in README

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687acda75e4c8333b38559ef6ff6bab1