### PR TITLE
Fix CI tag publish and skip modem in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
           docker run --rm -e DEVICE=/dev/null -e BAUDRATE=9600 \
             -e TELEGRAM_BOT_TOKEN=dummy -e TELEGRAM_CHAT_ID=dummy \
             -e GAMMU_SPOOL_PATH=/tmp/gammu -e GAMMU_CONFIG_PATH=/tmp/smsdrc \
+            -e CI_MODE=true \
             "$IMAGE" --dry-run
           docker run --rm --entrypoint gammu-smsd "$IMAGE" --version
 
@@ -90,6 +91,7 @@ jobs:
               environment:
                 TELEGRAM_BOT_TOKEN: dummy
                 TELEGRAM_CHAT_ID: dummy
+                CI_MODE: "true"
           EOF
           docker compose -f compose.yml up -d
           sleep 30

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Prepare meta
+        id: meta
+        run: echo "repo=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -22,6 +25,6 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ steps.meta.outputs.repo }}:${{ github.ref_name }}
+            ghcr.io/${{ steps.meta.outputs.repo }}:latest
 

--- a/README.md
+++ b/README.md
@@ -84,16 +84,18 @@ The CI pipeline runs these tests both on the host and again inside the built
 Docker image. The image is only pushed if all tests succeed, ensuring you can
 `docker pull` with confidence.
 
-## Release pipeline
+## CI / Tag release
 The Docker image is published to GitHub Container Registry whenever a git tag is pushed.
 
-**Secrets required**: none (uses the built-in `GITHUB_TOKEN`).
+**Secrets required**: none beyond the default `GITHUB_TOKEN`.
 
 Release with:
 
 ```sh
-git tag <version> && git push --tags
+git tag vX.Y.Z && git push --tags
 ```
+
+For hardware-less pipelines set `CI_MODE=true` so the entrypoint exits if no modem is found.
 
 ## Troubleshooting
 1. **Ports are visible on host?** `ls -l /dev/ttyUSB*`

--- a/tests/test_ci_mode.py
+++ b/tests/test_ci_mode.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+
+
+def test_ci_mode(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    # gammu should fail so device_ok returns false
+    (bin_dir / "gammu").symlink_to("/usr/bin/false")
+    env = os.environ.copy()
+    env.update({
+        "CI_MODE": "true",
+        "PATH": f"{bin_dir}:{env.get('PATH','')}",
+        "GAMMU_SPOOL_PATH": str(tmp_path / "spool"),
+        "GAMMU_CONFIG_PATH": str(tmp_path / "config"),
+    })
+    result = subprocess.run(["bash", "entrypoint.sh"], env=env, timeout=5, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "CI_MODE enabled" in result.stdout
+


### PR DESCRIPTION
## Summary
- lower-case repo for package tag publishing
- allow CI_MODE for entrypoint to skip modem loop
- set CI_MODE=true during integration tests
- document CI usage and release tagging
- add pytest to check CI_MODE path

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad104731c83339512ab3e5e2e87d1