### PR TITLE
Fix Docker build context and install package in image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.venv
+__pycache__/
+*.pyc
+*.log
+state/
+*.tar
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt \
     fi
 
 WORKDIR /app
+ENV PYTHONPATH="/app:${PYTHONPATH}"
 COPY . /app
+RUN pip install --no-cache-dir -e .
 RUN chmod +x /app/start.sh
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
## Summary
- add `.dockerignore` with minimal excludes
- set PYTHONPATH and install the package in editable mode

## Testing
- `black --check .`
- `ruff check .`
- `pytest -q`

The `docker` command was unavailable so image build and container tests were skipped.

------
https://chatgpt.com/codex/tasks/task_e_687be4da84b88333a8e6de0deb3fa8d1