### PR TITLE
Fix entrypoint, add compose health test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ghcr.io/alexbomber12/sms-gateway:${SMSGW_VERSION}
     build: .
     group_add: [dialout]
+    privileged: true
     devices:
       - /dev/serial/by-id/:/dev/serial/by-id/
     env_file:
@@ -12,7 +13,7 @@ services:
     volumes:
       - ./state:/var/spool/gammu
     healthcheck:
-      test: ["CMD-SHELL", "gammu --identify -c /tmp/gammu-smsdrc >/dev/null 2>&1"]
+      test: ["CMD-SHELL", "gammu identify -c /tmp/gammurc >/dev/null 2>&1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,51 @@
+import os
+import shutil
+import subprocess
+import time
+import pytest
+
+
+def docker_available():
+    if shutil.which("docker") is None:
+        return False
+    try:
+        subprocess.run(["docker", "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+docker_required = pytest.mark.skipif(not docker_available(), reason="docker unavailable")
+
+
+@docker_required
+def test_compose_service_healthy():
+    subprocess.run(["docker", "compose", "up", "-d"], check=True)
+    try:
+        deadline = time.time() + 60
+        status = ""
+        while time.time() < deadline:
+            result = subprocess.run([
+                "docker",
+                "inspect",
+                "--format",
+                "{{.State.Health.Status}}",
+                "smsgateway",
+            ], capture_output=True, text=True)
+            status = result.stdout.strip()
+            if status == "healthy":
+                break
+            time.sleep(1)
+        assert status == "healthy"
+        subprocess.run([
+            "docker",
+            "exec",
+            "smsgateway",
+            "gammu",
+            "identify",
+            "-c",
+            "/tmp/gammurc",
+        ], check=True)
+    finally:
+        subprocess.run(["docker", "compose", "down", "-v"], check=False)
+

--- a/tests/test_shellcheck.py
+++ b/tests/test_shellcheck.py
@@ -1,0 +1,7 @@
+import shutil
+import subprocess
+import pytest
+
+@pytest.mark.skipif(shutil.which("shellcheck") is None, reason="shellcheck missing")
+def test_entrypoint_shellcheck():
+    subprocess.run(["shellcheck", "entrypoint.sh"], check=True)


### PR DESCRIPTION
## Summary
- refactor `entrypoint.sh` into functions and call `main`
- generate modem configs and wait for modem using gammu
- export `DEV` and remove unreachable code
- adjust docker-compose to mount serial devices and use new configs
- add shellcheck regression test and docker compose health test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c250331948333b7299f3a21364643