### PR TITLE
Fix entrypoint and add docker health tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,14 @@ services:
     group_add: [dialout]
     devices:
       - /dev/serial/by-id/:/dev/serial/by-id/
+    privileged: true
     env_file:
       - .env
     restart: unless-stopped
     volumes:
       - ./state:/var/spool/gammu
     healthcheck:
-      test: ["CMD-SHELL", "gammu --identify -c /tmp/gammu-smsdrc >/dev/null 2>&1"]
+      test: ["CMD-SHELL", "gammu --identify -c /tmp/gammurc >/dev/null 2>&1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,60 +1,61 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ---- 0. Immediate bypasses ---------------------------------------------
-# Skip the modem scan entirely during CI or when explicitly requested. If a
-# command is supplied it is executed before exiting.
-if [[ "${CI_MODE:-}" == "true" || "${SKIP_MODEM:-}" == "true" ]]; then
-  echo "[entrypoint] Modem scan disabled."
-  [[ $# -gt 0 ]] && exec "$@"
-  exit 0
-fi
+log() { echo "[entrypoint] $*"; }
 
-# ---- 1. Normal production path (modem auto-scan once) -------------------
+find_device() {
+  for d in /dev/serial/by-id/* /dev/ttyUSB0; do
+    [[ -r "$d" ]] && echo "$d" && return 0
+  done
+  return 1
+}
 
-log(){ echo "[entrypoint] $*"; }
-
-LOGLEVEL="${LOGLEVEL:-1}"
-GAMMU_SPOOL_PATH="${GAMMU_SPOOL_PATH:-/var/spool/gammu}"
-
-mkdir -p "$GAMMU_SPOOL_PATH"/{inbox,outbox,sent,error,archive}
-
-# ---- 2. Detect modem ----------------------------------------------------
-# ------------------------------------------------------------------
-# 1. build candidate list
-CANDIDATES=()
-[ -n "${MODEM_PORT}" ] && CANDIDATES+=("${MODEM_PORT}")
-CANDIDATES+=(/dev/serial/by-id/* /dev/ttyUSB*)
-
-# 2. probe each candidate
-for DEV in "${CANDIDATES[@]}"; do
-  [ -e "${DEV}" ] || continue
-
-  # create minimal config for the probe
-  cat > /tmp/gammurc <<EOF
+generate_configs() {
+  local dev="$1"
+  cat > /tmp/gammurc <<CONF
 [gammu]
-device = ${DEV}
+device  = ${dev}
 connection = at
-EOF
-
-  # give up after 12 s if no reply
-  if timeout 12 gammu --config /tmp/gammurc identify >/dev/null 2>&1; then
-    echo "✅ Using modem ${DEV}"
-
-    # full config for smsd
-    cat > /tmp/gammu-smsdrc <<EOF
+CONF
+  cat > /tmp/gammu-smsdrc <<CONF
 [gammu]
-device = ${DEV}
+device  = ${dev}
 connection = at
 
 [smsd]
 service = files
-EOF
+CONF
+}
 
-    exec gammu-smsd -c /tmp/gammu-smsdrc -f
+wait_for_modem() {
+  local timeout="${MODEM_TIMEOUT:-30}"
+  until gammu --identify -c /tmp/gammurc >/dev/null 2>&1; do
+    ((timeout--)) || { log "Modem not found"; exit 70; }
+    sleep 1
+  done
+  log "Modem detected"
+}
+
+main() {
+  if [[ "${CI_MODE:-}" == "true" || "${SKIP_MODEM:-}" == "true" ]]; then
+    log "Modem scan disabled."
+    [[ $# -gt 0 ]] && exec "$@"
+    exit 0
   fi
-done
 
-echo "❌ No responsive modem found"
-exit 1
-# ------------------------------------------------------------------
+  LOGLEVEL="${LOGLEVEL:-1}"
+  GAMMU_SPOOL_PATH="${GAMMU_SPOOL_PATH:-/var/spool/gammu}"
+  mkdir -p "$GAMMU_SPOOL_PATH"/{inbox,outbox,sent,error,archive}
+
+  DEV=$(find_device || true)
+  if [[ -z "${DEV:-}" ]]; then
+    log "No modem device found"
+    exit 70
+  fi
+  export DEV
+  generate_configs "$DEV"
+  wait_for_modem
+  exec gammu-smsd -c /tmp/gammu-smsdrc -f
+}
+
+main "$@"

--- a/tests/test_compose_health.py
+++ b/tests/test_compose_health.py
@@ -1,0 +1,86 @@
+import os
+import subprocess
+import time
+import pty
+import threading
+import shutil
+import pytest
+
+
+class FakeModem(threading.Thread):
+    def __init__(self):
+        super().__init__(daemon=True)
+        self.master, self.slave = pty.openpty()
+        self.path = os.ttyname(self.slave)
+        self.running = True
+
+    def run(self):
+        with os.fdopen(self.master, 'rb+', buffering=0) as fd:
+            while self.running:
+                data = fd.readline()
+                if not data:
+                    continue
+                cmd = data.strip().decode('ascii', 'ignore')
+                if cmd in ('AT', 'ATE0'):
+                    fd.write(b'OK\r\n')
+                elif cmd == 'AT+CGMI':
+                    fd.write(b'Generic\r\nOK\r\n')
+                elif cmd == 'AT+CGMM':
+                    fd.write(b'Model\r\nOK\r\n')
+                elif cmd == 'AT+CGMR':
+                    fd.write(b'1.0\r\nOK\r\n')
+                elif cmd == 'AT+CGSN':
+                    fd.write(b'12345\r\nOK\r\n')
+                else:
+                    fd.write(b'OK\r\n')
+
+    def stop(self):
+        self.running = False
+
+
+def test_container_becomes_healthy(tmp_path):
+    if not shutil.which('docker'):
+        pytest.skip('docker not available')
+
+    image = 'smsgateway:test'
+    subprocess.run(['docker', 'build', '-t', image, '.'], check=True)
+
+    modem = FakeModem(); modem.start()
+    compose = tmp_path / 'compose.yml'
+    compose.write_text(
+        f"""
+services:
+  smsgateway:
+    image: {image}
+    devices:
+      - {modem.path}:/dev/ttyUSB0
+    privileged: true
+    environment:
+      TELEGRAM_BOT_TOKEN: dummy
+      TELEGRAM_CHAT_ID: dummy
+    healthcheck:
+      test: [\"CMD-SHELL\", \"gammu --identify -c /tmp/gammurc >/dev/null 2>&1\"]
+      interval: 1s
+      timeout: 1s
+      retries: 60
+"""
+    )
+
+    subprocess.run(['docker', 'compose', '-f', str(compose), 'up', '-d'], check=True)
+    try:
+        status = ''
+        for _ in range(60):
+            status = subprocess.check_output(
+                ['docker', 'inspect', '--format', '{{.State.Health.Status}}', 'smsgateway'],
+                text=True,
+            ).strip()
+            if status == 'healthy':
+                break
+            time.sleep(1)
+        assert status == 'healthy'
+        subprocess.run([
+            'docker', 'exec', 'smsgateway', 'gammu', '--identify', '-c', '/tmp/gammurc'
+        ], check=True)
+    finally:
+        subprocess.run(['docker', 'compose', '-f', str(compose), 'down', '-v'], check=False)
+        modem.stop()

--- a/tests/test_shellcheck.py
+++ b/tests/test_shellcheck.py
@@ -1,0 +1,5 @@
+import subprocess
+
+
+def test_shellcheck_entrypoint():
+    subprocess.run(["shellcheck", "entrypoint.sh"], check=True)


### PR DESCRIPTION
## Summary
- refactor `entrypoint.sh` so functions precede calls and use a modem timeout loop
- detect modem device and generate configs at runtime
- update docker-compose to use `/tmp/gammurc` for health check and run in `privileged` mode
- add a ShellCheck regression test
- add an end-to-end docker-compose health test using a fake modem emulator

## Testing
- `shellcheck entrypoint.sh`
- `pytest -q` *(fails: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_687c250331948333b7299f3a21364643