### PR TITLE
Refactor CI workflow to stop pushing images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: ci
 on:
   push:
     branches: [main]
-    tags: ['*']
   pull_request:
     branches: [main]
 
@@ -40,25 +39,22 @@ jobs:
             echo "IMAGE=$REPO" >> "$GITHUB_ENV"
 
       - uses: docker/setup-buildx-action@v3
-        if: github.event_name != 'pull_request'
 
       - name: shellcheck entrypoint
-        if: github.event_name != 'pull_request'
         uses: ludeeus/action-shellcheck@master
         with:
           check_together: 'entrypoint.sh'
 
       - name: Build Docker image
-        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v5
         with:
           context: .
           load: true
+          push: false
           tags: ${{ steps.vars.outputs.tags }}
           build-args: INSTALL_DEV_DEPS=true
 
       - name: Run all tests inside built Docker image
-        if: github.event_name != 'pull_request'
         run: |
           IMAGE=$(echo "${{ steps.vars.outputs.tags }}" | cut -d',' -f1)
           docker run --rm \
@@ -69,7 +65,6 @@ jobs:
             "$IMAGE" pytest -v
 
       - name: Smoke test container
-        if: github.event_name != 'pull_request'
         run: |
           IMAGE=$(echo "${{ steps.vars.outputs.tags }}" | cut -d',' -f1)
           docker run --rm -e DEVICE=/dev/null -e BAUDRATE=9600 \
@@ -80,7 +75,6 @@ jobs:
           docker run --rm --entrypoint gammu-smsd "$IMAGE" --version
 
       - name: smoke test with compose
-        if: github.event_name != 'pull_request'
         run: |
           IMAGE=$(echo "${{ steps.vars.outputs.tags }}" | cut -d',' -f1)
           export IMAGE
@@ -89,17 +83,3 @@ jobs:
           docker compose -f compose.ci.yml ps
           docker compose -f compose.ci.yml logs smsgateway
           docker compose -f compose.ci.yml down
-
-      - uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push Docker image
-        if: github.event_name != 'pull_request'
-        run: |
-          for tag in $(echo "${{ steps.vars.outputs.tags }}" | tr ',' ' '); do
-            docker push "$tag"
-          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,20 +23,12 @@ jobs:
           CI_MODE: "true"
         run: pytest -v
 
-      - name: Set image tags
-        if: github.event_name != 'pull_request'
+
+      - name: Docker meta
         id: vars
-        run: |
-            REPO=ghcr.io/$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
-            TAGS="$REPO:${GITHUB_SHA}"
-            if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-              TAGS="$TAGS,$REPO:${GITHUB_REF_NAME}"
-            fi
-            if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-              TAGS="$TAGS,$REPO:latest"
-            fi
-            echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
-            echo "IMAGE=$REPO" >> "$GITHUB_ENV"
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary
- run CI on pushes and PRs only
- stop logging into Docker registry and pushing images
- run build and smoke tests for PRs as well

## Testing
- `pytest -q`
- `pre-commit run --files .github/workflows/build.yml`

------
https://chatgpt.com/codex/tasks/task_e_687c3f9aa2cc833383d0edd5b5f92b05