### PR TITLE
Fix compose build and entrypoint args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   smsgateway:
     container_name: smsgateway
     image: ghcr.io/alexbomber12/sms-gateway:${SMSGW_VERSION}
-    build: .
     group_add: [dialout]
     privileged: true
     devices:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,13 +82,15 @@ detect_modem() {
 }
 
 main() {
-  LOGLEVEL="${LOGLEVEL:-1}"
   GAMMU_SPOOL_PATH="${GAMMU_SPOOL_PATH:-/var/spool/gammu}"
   mkdir -p "$GAMMU_SPOOL_PATH"/{inbox,outbox,sent,error,archive}
 
   detect_modem || exit 70
 
-  exec gammu-smsd -c /tmp/gammu-smsdrc -f
+  args=( -c /tmp/gammu-smsdrc )
+  [[ -n "${LOGLEVEL:-}"        ]] && args+=( -d "$LOGLEVEL" )
+  [[ "${FOREGROUND:-false}" == "true" ]] && args+=( -f )
+  exec gammu-smsd "${args[@]}"
 }
 
 # ---- Immediate bypasses -------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure docker compose doesn't rebuild image
- handle LOGLEVEL and FOREGROUND flags safely

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c4c45f8948333b6994d0dba00e529