### PR TITLE
Fix gammu-smsd args for v1.42

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,8 +88,14 @@ main() {
   detect_modem || exit 70
 
   args=( -c /tmp/gammu-smsdrc )
-  [[ -n "${LOGLEVEL:-}"        ]] && args+=( -d "$LOGLEVEL" )
-  [[ "${FOREGROUND:-false}" == "true" ]] && args+=( -f )
+
+  if [[ -n "${LOGLEVEL:-}" ]]; then
+    grep -q '^\[smsd\]' /tmp/gammu-smsdrc || echo '[smsd]' >> /tmp/gammu-smsdrc
+    sed -i '/^\[smsd\]/,/^\[/ { /^DebugLevel[[:space:]]*=.*/d }' /tmp/gammu-smsdrc
+    sed -i '/^\[smsd\]/a DebugLevel = '"$LOGLEVEL"'' /tmp/gammu-smsdrc
+  fi
+
+  [[ "${FOREGROUND:-false}" != "true" ]] && args+=( --daemon )
   exec gammu-smsd "${args[@]}"
 }
 


### PR DESCRIPTION
## Summary
- handle debug level in config instead of CLI flag
- support --daemon when not running in the foreground
- remove obsolete flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5a515b9c8333a84975b53ddcca52