### PR TITLE
Fix gammu-smsd startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,14 @@ services:
     privileged: true
     devices:
       - /dev/serial/by-id/:/dev/serial/by-id/
+      - /dev/ttyUSB0:/dev/ttyUSB0
     env_file:
       - .env
     restart: unless-stopped
     volumes:
       - ./state:/var/spool/gammu
+      - ./smsdrc:/etc/gammu-smsdrc:ro
+    entrypoint: ./entrypoint.sh
     healthcheck:
       test: ["CMD-SHELL", "gammu --identify -c /tmp/gammu-smsdrc >/dev/null 2>&1"]
       interval: 30s


### PR DESCRIPTION
## Summary
- autodetect modem and use /tmp/gammu-smsdrc
- allow overriding config by mounting smsdrc
- expose gammu logs on stdout
- make compose use the new entrypoint and mount config

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c6baf830483338ae3126a74a70eef