### PR TITLE
Improve container health management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,13 @@ services:
       - .env
     environment:
       MODEM_PORT: /dev/ttyUSB0
-    restart: unless-stopped
+    restart: always
     volumes:
       - ./state:/var/spool/gammu
     entrypoint: ./entrypoint.sh
     healthcheck:
-      test: ["CMD-SHELL", "gammu --identify -c /tmp/gammu-smsdrc >/dev/null 2>&1"]
-      interval: 30s
-      timeout: 5s
+      test: ["CMD-SHELL", "gammu identify -c /tmp/gammu-smsdrc >/dev/null 2>&1"]
+      interval: 60s
+      timeout: 10s
       retries: 3
       start_period: 15s


### PR DESCRIPTION
## Summary
- replace `unless-stopped` with `always` restart policy
- adjust health check to use `gammu identify`
- lengthen health-check interval and timeout

## Testing
- `make lint`
- `make test` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_687ffb3ae2f88333a3d90a4e56ebe5e4