### PR TITLE
Improve modem detection watchdog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,13 @@ services:
       - .env
     environment:
       MODEM_PORT: /dev/ttyUSB0
-    restart: unless-stopped
     volumes:
       - ./state:/var/spool/gammu
     entrypoint: ./entrypoint.sh
     healthcheck:
       test: ["CMD-SHELL", "gammu identify -c /tmp/gammu-smsdrc >/dev/null 2>&1"]
-      interval: 60s
+      interval: 1m
       timeout: 10s
       retries: 3
-      start_period: 15s
+      start_period: 20s
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- enhance `detect_modem` to probe all USB ports via `gammu identify`
- restart modem automatically with a watchdog that re-probes after failures
- adjust healthcheck timings in compose file

## Testing
- `ruff check .`
- `black --check .`
- `/root/.pyenv/versions/3.12.10/bin/yamllint docker-compose.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827cfb1c2883338f40acebe27a07c8