### PR TITLE
Add USB modem watchdog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.12-slim
 
 ARG INSTALL_DEV_DEPS="false"
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        gammu gammu-smsd usbutils procps && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        cron usb-modeswitch usbutils gammu gammu-smsd procps \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN usermod -a -G dialout root
 
@@ -24,7 +24,7 @@ RUN chmod +x /app/start.sh
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
 COPY smsgw-watchdog.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/smsgw-watchdog.sh
+RUN chmod 755 /usr/local/bin/smsgw-watchdog.sh
 COPY smsgw-watchdog.cron /etc/cron.d/
 RUN chmod 644 /etc/cron.d/smsgw-watchdog.cron && crontab /etc/cron.d/smsgw-watchdog.cron
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,8 @@ RUN pip install --no-cache-dir -e .
 RUN chmod +x /app/start.sh
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY smsgw-watchdog.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/smsgw-watchdog.sh
+COPY smsgw-watchdog.cron /etc/cron.d/
+RUN chmod 644 /etc/cron.d/smsgw-watchdog.cron && crontab /etc/cron.d/smsgw-watchdog.cron
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     group_add: [dialout]
     devices:
       - /dev/ttyUSB0:/dev/ttyUSB0        # only initial mapping; others appear automatically
+      - /dev/usb:/dev/usb               # pass whole usb bus for reset
     env_file: [.env]
     volumes:
       - ./state:/var/spool/gammu

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,12 +3,7 @@
 ## Modem watchdog
 The image installs `/usr/local/bin/smsgw-watchdog.sh` and schedules it via `/etc/cron.d/smsgw-watchdog.cron`.
 Every five minutes the script checks the health of the `smsgateway` container.
-When it is reported as *unhealthy* the script performs a soft USB reset using:
+When it is reported as *unhealthy* the script detects the Huawei modem's current PID with `lsusb`, performs a soft USB reset and restarts the container.
 
-```bash
-usb_modeswitch -v 12d1 -p 1506 -R
-```
-
-After waiting 15&nbsp;seconds for the modem to reappear the container is restarted.
-To use a different modem change the `VID` and `PID` variables at the top of the script.
+To adapt to other Huawei models change the `VID` variable in the script. The PID is discovered automatically.
 All output is appended to `/var/log/smsgw-watchdog.log` on the host.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+# Documentation
+
+## Modem watchdog
+The image installs `/usr/local/bin/smsgw-watchdog.sh` and schedules it via `/etc/cron.d/smsgw-watchdog.cron`.
+Every five minutes the script checks the health of the `smsgateway` container.
+When it is reported as *unhealthy* the script performs a soft USB reset using:
+
+```bash
+usb_modeswitch -v 12d1 -p 1506 -R
+```
+
+After waiting 15&nbsp;seconds for the modem to reappear the container is restarted.
+To use a different modem change the `VID` and `PID` variables at the top of the script.
+All output is appended to `/var/log/smsgw-watchdog.log` on the host.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -96,6 +96,8 @@ main() {
   GAMMU_SPOOL_PATH="${GAMMU_SPOOL_PATH:-/var/spool/gammu}"
   mkdir -p "$GAMMU_SPOOL_PATH"/{inbox,outbox,sent,error,archive}
 
+  service cron start >/dev/null
+
   if ! use_mounted_config; then
     detect_modem || exit 70
   fi
@@ -125,7 +127,8 @@ main() {
         fi
       fi
     else
-      fail=0
+      # keep fail count until modem re-probe succeeds
+      :
     fi
     sleep 5
   done

--- a/smsgw-watchdog.cron
+++ b/smsgw-watchdog.cron
@@ -1,1 +1,1 @@
-*/5 * * * * /usr/local/bin/smsgw-watchdog.sh
+*/5 * * * * root /usr/local/bin/smsgw-watchdog.sh >> /var/log/smsgw-watchdog.log 2>&1

--- a/smsgw-watchdog.cron
+++ b/smsgw-watchdog.cron
@@ -1,1 +1,3 @@
+SHELL=/bin/bash
+CRON_TZ=UTC
 */5 * * * * root /usr/local/bin/smsgw-watchdog.sh >> /var/log/smsgw-watchdog.log 2>&1

--- a/smsgw-watchdog.sh
+++ b/smsgw-watchdog.sh
@@ -1,7 +1,15 @@
-#!/bin/bash
-set -e
-STATUS=$(docker inspect --format '{{.State.Health.Status}}' smsgateway || echo notfound)
-if [ "$STATUS" = "unhealthy" ]; then
-  logger -t smsgw "Container unhealthy – restarting"
-  docker restart smsgateway
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER="smsgateway"
+VID="12d1"
+PID="1506"
+
+health=$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "notfound")
+
+if [[ "$health" == "unhealthy" ]]; then
+  logger -t smsgw "watchdog: container unhealthy → resetting modem"
+  usb_modeswitch -v "$VID" -p "$PID" -R  >/dev/null 2>&1 || true
+  sleep 15
+  docker restart "$CONTAINER"
 fi

--- a/smsgw-watchdog.sh
+++ b/smsgw-watchdog.sh
@@ -2,14 +2,19 @@
 set -euo pipefail
 
 CONTAINER="smsgateway"
-VID="12d1"
-PID="1506"
+VID="12d1"                            # Huawei vendor
+PID=$(lsusb -d ${VID}: | awk '{print $6}' | head -n1 | cut -d: -f2)
+
+if [[ -z "$PID" ]]; then
+  logger -t smsgw "watchdog: no Huawei device found, skipping"
+  exit 0
+fi
 
 health=$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "notfound")
 
 if [[ "$health" == "unhealthy" ]]; then
-  logger -t smsgw "watchdog: container unhealthy → resetting modem"
-  usb_modeswitch -v "$VID" -p "$PID" -R  >/dev/null 2>&1 || true
+  logger -t smsgw "watchdog: container unhealthy, resetting modem ${VID}:${PID}"
+  usb_modeswitch -v "$VID" -p "$PID" -R >/dev/null 2>&1 || true
   sleep 15
   docker restart "$CONTAINER"
 fi


### PR DESCRIPTION
## Summary
- reboot unhealthy gateway with a watchdog
- install watchdog in Dockerfile
- expose usb bus and run watchdog via cron
- document the modem watchdog

## Testing
- `pre-commit run --files Dockerfile docker-compose.yml smsgw-watchdog.cron smsgw-watchdog.sh docs/README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858185c1a08333af1b524b224c05de