### PR TITLE
Update CI tests to use python -m pytest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run tests
         env:
           CI_MODE: "true"
-        run: sudo -E pytest -v
+        run: sudo -E python -m pytest -v
 
       - name: Docker meta
         id: vars


### PR DESCRIPTION
## Summary
- use `python -m pytest` in the CI test step

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68868fd9d8508333abb5855d88fec3c4