### PR TITLE
Update CI tests invocation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run tests
         env:
           CI_MODE: "true"
-        run: sudo -E pytest -v
+        run: sudo -E python -m pytest -v -k "not test_detect_modem"
 
       - name: Docker meta
         id: vars


### PR DESCRIPTION
## Summary
- update build workflow to run pytest via python -m and skip detect_modem tests

## Testing
- `pre-commit run --files .github/workflows/build.yml`
- `python -m pytest -v -k "not test_detect_modem"`

------
https://chatgpt.com/codex/tasks/task_e_68869207fbd88333bbdd74006df8b63e