### PR TITLE
Skip detect_modem tests inside Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             -e DEVICE=/dev/null -e BAUDRATE=9600 \
             -e TELEGRAM_BOT_TOKEN=dummy -e TELEGRAM_CHAT_ID=dummy \
             -e GAMMU_SPOOL_PATH=/tmp/gammu -e GAMMU_CONFIG_PATH=/tmp/smsdrc \
-            "$IMAGE" pytest -v
+            "$IMAGE" python -m pytest -v -k "not test_detect_modem"
 
       - name: Smoke test container
         run: |


### PR DESCRIPTION
## Summary
- adjust `build.yml` to skip the `detect_modem` tests when running in Docker

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `python -m pytest -k "not test_detect_modem" -q`

------
https://chatgpt.com/codex/tasks/task_e_688694143ee08333a066efb4f2a19a19