### PR TITLE
Update build workflow to skip modem test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run tests
         env:
           CI_MODE: "true"
-        run: sudo -E pytest -v
+        run: sudo -E python -m pytest -v -k "not test_detect_modem"
 
       - name: Docker meta
         id: vars


### PR DESCRIPTION
## Summary
- run tests with `python -m pytest`
- skip `test_detect_modem` in CI

## Testing
- `pytest -v -k "not test_detect_modem"`

------
https://chatgpt.com/codex/tasks/task_e_6886956bd5188333a16db6d369cd7c37