### PR TITLE
Skip detect_modem tests in Docker test step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             -e DEVICE=/dev/null -e BAUDRATE=9600 \
             -e TELEGRAM_BOT_TOKEN=dummy -e TELEGRAM_CHAT_ID=dummy \
             -e GAMMU_SPOOL_PATH=/tmp/gammu -e GAMMU_CONFIG_PATH=/tmp/smsdrc \
-            "$IMAGE" pytest -v
+            "$IMAGE" python -m pytest -v -k "not test_detect_modem"
 
       - name: Smoke test container
         run: |


### PR DESCRIPTION
## Summary
- adjust CI workflow to skip detect_modem tests when running in Docker

## Testing
- `pre-commit run --files .github/workflows/build.yml`
- `pytest -k "not test_detect_modem"`

------
https://chatgpt.com/codex/tasks/task_e_6886968db8848333bd853871c6626e04