### PR TITLE
Fix package workflow unit tests

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -58,6 +58,10 @@ jobs:
         if: always()
         run: |
           docker run --rm \
+            -e CI_MODE=true \
+            -e DEVICE=/dev/null -e BAUDRATE=9600 \
+            -e TELEGRAM_BOT_TOKEN=dummy -e TELEGRAM_CHAT_ID=dummy \
+            -e GAMMU_SPOOL_PATH=/tmp/gammu -e GAMMU_CONFIG_PATH=/tmp/smsdrc \
             ghcr.io/${{ steps.meta.outputs.repo }}:${{ github.sha }} \
             python -m pytest -q -k "not test_detect_modem"
 


### PR DESCRIPTION
## Summary
- run package job tests with CI_MODE enabled
- skip modem detection tests in the container

## Testing
- `pre-commit run --files .github/workflows/package.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879c855d4c8333b43a73a3b041ec04