### PR TITLE
Improve modem handling when unavailable

### DIFF
--- a/tests/test_ci_mode.py
+++ b/tests/test_ci_mode.py
@@ -1,11 +1,13 @@
 import subprocess
 import pathlib
+import time
 
-assert (
-    subprocess.run(
-        [pathlib.Path("entrypoint.sh").resolve()],
-        env={"CI_MODE": "true"},
-        timeout=3,
-    ).returncode
-    == 0
+proc = subprocess.Popen(
+    [pathlib.Path("entrypoint.sh").resolve()], env={"CI_MODE": "true"}
 )
+try:
+    time.sleep(1)
+    assert proc.poll() is None
+finally:
+    proc.terminate()
+    proc.wait(timeout=3)


### PR DESCRIPTION
## Summary
- keep container alive when modem scanning is skipped
- retry modem detection indefinitely every 30 seconds
- keep watchdog running and keep probing modem instead of exiting
- update unit tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b58792448333a6879fb02d5e5153