### PR TITLE
Handle modem disappearance with USB reset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ TELEGRAM_BOT_TOKEN=your_token    # Required - Telegram bot token
 TELEGRAM_CHAT_ID=your_chat_id    # Required - Telegram chat ID
 LOGLEVEL=INFO                    # Optional - logging level (INFO or DEBUG)
 GAMMU_SPOOL_PATH=/var/spool/gammu # Optional - path for Gammu spool directories
+USB_VID=                          # Optional - USB vendor ID for modem reset
+USB_PID=                          # Optional - USB product ID for modem reset

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ These settings give the container access to the modem.
 | TELEGRAM_CHAT_ID | ✅ | Chat ID to receive forwarded messages |
 | LOGLEVEL | ❌ | Logging level: INFO, DEBUG, WARNING, etc. |
 | GAMMU_SPOOL_PATH | ❌ | Path for Gammu spool directories |
+| USB_VID | ❌ | USB vendor ID for modem resets |
+| USB_PID | ❌ | USB product ID for modem resets |
 
 ## E. Container Debugging & Manual Testing
 ```bash

--- a/tests/test_detect_modem.py
+++ b/tests/test_detect_modem.py
@@ -63,11 +63,11 @@ def test_retry_loop_retries(tmp_path):
         "detect_modem() { return 1; }\n"
         "sleep() { count=$((count+1)); [ $count -ge 3 ] && exit 0; }\n"
         "count=0\n"
-        "until detect_modem; do echo retry$count; sleep 30; done"
+        "until detect_modem; do reset_modem; echo retry$count; sleep 30; done"
     )
     res = run_bash(loop, env)
     assert res.returncode == 0
-    assert res.stdout.count('retry') == 3
+    assert res.stdout.count("retry") == 3
 
 
 def test_retry_loop_succeeds(tmp_path):
@@ -77,7 +77,7 @@ def test_retry_loop_succeeds(tmp_path):
         "idx=0\n"
         "detect_modem() { rc=${codes[$idx]}; idx=$((idx+1)); return $rc; }\n"
         "sleep() { :; }\n"
-        "until detect_modem; do sleep 30; done; echo calls=$idx"
+        "until detect_modem; do reset_modem; sleep 30; done; echo calls=$idx"
     )
     res = run_bash(loop, env)
     assert res.returncode == 0


### PR DESCRIPTION
## Summary
- handle USB vendor and product ID in `entrypoint.sh`
- reset modem when probing fails during startup and watchdog retries
- update retry logic tests for reset function
- document `USB_VID` and `USB_PID`

## Testing
- `pre-commit run --files entrypoint.sh README.md .env.example tests/test_detect_modem.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887bece08fc833390cac4d847efa3dc