### PR TITLE
Fix package unit tests for no-modem environment

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -56,15 +56,23 @@ jobs:
 
       - name: unit tests
         if: always()
+        env:
+          CI_MODE: "true"
+          DEVICE: /dev/null
+          BAUDRATE: "9600"
+          TELEGRAM_BOT_TOKEN: dummy
+          TELEGRAM_CHAT_ID: dummy
+          GAMMU_SPOOL_PATH: /tmp/gammu
+          GAMMU_CONFIG_PATH: /tmp/smsdrc
         run: |
           docker run --rm \
-            -e CI_MODE=true \
-            -e DEVICE=/dev/null \
-            -e BAUDRATE=9600 \
-            -e TELEGRAM_BOT_TOKEN=dummy \
-            -e TELEGRAM_CHAT_ID=dummy \
-            -e GAMMU_SPOOL_PATH=/tmp/gammu \
-            -e GAMMU_CONFIG_PATH=/tmp/smsdrc \
+            -e CI_MODE \
+            -e DEVICE \
+            -e BAUDRATE \
+            -e TELEGRAM_BOT_TOKEN \
+            -e TELEGRAM_CHAT_ID \
+            -e GAMMU_SPOOL_PATH \
+            -e GAMMU_CONFIG_PATH \
             ghcr.io/${{ steps.meta.outputs.repo }}:${{ github.sha }} \
             python -m pytest -q -k "not test_detect_modem"
 


### PR DESCRIPTION
## Summary
- configure container unit test environment variables and run pytest skipping modem detection

## Testing
- `CI_MODE=true DEVICE=/dev/null BAUDRATE=9600 TELEGRAM_BOT_TOKEN=dummy TELEGRAM_CHAT_ID=dummy GAMMU_SPOOL_PATH=/tmp/gammu GAMMU_CONFIG_PATH=/tmp/smsdrc python -m pytest -q -k "not test_detect_modem"`

------
https://chatgpt.com/codex/tasks/task_e_6887cbed1ccc83339af82569c17e879e