### PR TITLE
Set SKIP_MODEM for package tests and compose

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -58,6 +58,7 @@ jobs:
         if: always()
         env:
           CI_MODE: "true"
+          SKIP_MODEM: "true"
           DEVICE: /dev/null
           BAUDRATE: "9600"
           TELEGRAM_BOT_TOKEN: dummy
@@ -67,6 +68,7 @@ jobs:
         run: |
           docker run --rm \
             -e CI_MODE \
+            -e SKIP_MODEM \
             -e DEVICE \
             -e BAUDRATE \
             -e TELEGRAM_BOT_TOKEN \

--- a/compose.ci.yml
+++ b/compose.ci.yml
@@ -5,6 +5,7 @@ services:
       TELEGRAM_BOT_TOKEN: dummy
       TELEGRAM_CHAT_ID: dummy
       CI_MODE: "true"
+      SKIP_MODEM: "true"
     group_add:
       - dialout
     restart: "no"


### PR DESCRIPTION
## Summary
- set `SKIP_MODEM=true` during package workflow tests
- pass the env variable to docker and compose

## Testing
- `pre-commit run --files .github/workflows/package.yml compose.ci.yml`
- `pytest -q -k "not test_detect_modem"`

------
https://chatgpt.com/codex/tasks/task_e_6887db3839788333a84375d9f595ca38