### PR TITLE
Fix formatting for test_ci_mode.py

### DIFF
--- a/tests/test_ci_mode.py
+++ b/tests/test_ci_mode.py
@@ -2,9 +2,7 @@ import subprocess
 import pathlib
 import time
 
-proc = subprocess.Popen(
-    [pathlib.Path("entrypoint.sh").resolve()], env={"CI_MODE": "true"}
-)
+proc = subprocess.Popen([pathlib.Path("entrypoint.sh").resolve()], env={"CI_MODE": "true"})
 try:
     time.sleep(1)
     assert proc.poll() is None


### PR DESCRIPTION
## Summary
- format tests/test_ci_mode.py with `black`

## Testing
- `black --check tests/test_ci_mode.py`

------
https://chatgpt.com/codex/tasks/task_e_6887faa13fa08333b89c9c52eabc6857